### PR TITLE
chore: bump `vd2hc` to 0.0.6

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ import { DataTable } from "@/components/DataTable";
 import { MetadataUploader } from "@/components/MetadataUploader";
 import { MintHypercerts } from "@/components/MintHypercerts";
 
-const VD_REPORTS_ENDPOINT = "https://directus.vd-dev.org/items/reports";
+const VD_REPORTS_ENDPOINT = "https://directus.vd-dev.org/";
 
 interface Report {
   title: string | null;
@@ -38,6 +38,7 @@ interface Report {
   date_updated: string | null;
   byline: string | null;
   total_cost: string | null;
+  hypercert_id: string | null;
 }
 
 export type MintData = HypercertMetadata & { cid: string };

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.49.3",
-    "vd2hc": "^0.0.2",
+    "vd2hc": "^0.0.6",
     "viem": "^1.21.4",
     "wagmi": "^1.4.13",
     "webpack-node-externals": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -78,8 +78,8 @@ dependencies:
     specifier: ^7.49.3
     version: 7.49.3(react@18.2.0)
   vd2hc:
-    specifier: ^0.0.2
-    version: 0.0.2(esbuild@0.20.0)(react@18.2.0)(rollup@4.9.6)(typescript@5.3.2)(zod@3.22.4)
+    specifier: ^0.0.6
+    version: 0.0.6(esbuild@0.20.0)(react@18.2.0)(rollup@4.9.6)(typescript@5.3.2)(zod@3.22.4)
   viem:
     specifier: ^1.21.4
     version: 1.21.4(typescript@5.3.2)(zod@3.22.4)
@@ -1520,6 +1520,17 @@ packages:
       sha.js: 2.4.11
     transitivePeerDependencies:
       - supports-color
+    dev: false
+
+  /@directus/sdk@15.0.1:
+    resolution: {integrity: sha512-NuP+S2SZ23gmcSNnHiX7LxlUxkdIjX0mV3kFKqTdU07epj4OJNHk7ZXfSV2y67fnQjFrb7apTHe2LdWnU8Y6vQ==}
+    engines: {node: '>=18.0.0'}
+    dependencies:
+      '@directus/system-data': 1.0.0
+    dev: false
+
+  /@directus/system-data@1.0.0:
+    resolution: {integrity: sha512-AKzYkLg39phx9AysQhcf7AmIGq1D/PIkor5B8Y5NB8R+jq+jkH1PBtg/l5Ev4hfsidpNBi5DmpuFy/xmQEYhHQ==}
     dev: false
 
   /@emotion/babel-plugin@11.11.0:
@@ -10370,10 +10381,11 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vd2hc@0.0.2(esbuild@0.20.0)(react@18.2.0)(rollup@4.9.6)(typescript@5.3.2)(zod@3.22.4):
-    resolution: {integrity: sha512-Xa+PnyETQwTUPEJKPQ3EJuWd4Hwe2Vf7iZFFghre8nGvE/uzdMaMl3Jk6KWknrEEH63mrOzlV5cxcR+zf3Hr/g==}
+  /vd2hc@0.0.6(esbuild@0.20.0)(react@18.2.0)(rollup@4.9.6)(typescript@5.3.2)(zod@3.22.4):
+    resolution: {integrity: sha512-rzqpmVXJ3XoIzz92CvQ6FokwZIfTa9JlB2Cs4qJo3OnkexYd9W36fye1R39AlyEbpPCk9arOZMsFY9j8SjNILA==}
     engines: {node: '>=18.0.0'}
     dependencies:
+      '@directus/sdk': 15.0.1
       '@hypercerts-org/sdk': 1.4.2-alpha.1(react@18.2.0)(typescript@5.3.2)(zod@3.22.4)
       rollup-plugin-esbuild: 6.1.1(esbuild@0.20.0)(rollup@4.9.6)
     transitivePeerDependencies:


### PR DESCRIPTION
- `vd2hc` now exclusively retrieves reports from the CMS that are marked as published and have a empty `hypercert_id`